### PR TITLE
Refactor Upload. _convertFileToCsv to use arrow function for PHP ≥8.4

### DIFF
--- a/warranty_upload.php
+++ b/warranty_upload.php
@@ -76,7 +76,10 @@ class Warranty_upload
 
     private function _convertFileToCsv($file)
     {
-        $csv = array_map('str_getcsv', file($file));
+        $csv = array_map(
+    		fn($line) => str_getcsv($line, ',', '"', ''),
+    		file($file)
+		);        
         array_walk($csv, function(&$a) use ($csv) {
             $a = array_combine($csv[0], $a);
         });


### PR DESCRIPTION
Avoids a deprecation warning in PHP ≥ 8.4:
Deprecated: str_getcsv(): the $escape parameter must be provided as its default value will change in /Users/Shared/munkireport-php/vendor/munkireport/warranty/warranty_upload.php on line 79